### PR TITLE
Add Save Bar, Loading, and NavMenu App Bridge features

### DIFF
--- a/admin-frame/src/App.tsx
+++ b/admin-frame/src/App.tsx
@@ -1,11 +1,15 @@
 import { EmbeddedApp } from "./components/EmbeddedApp"
 import { Modal } from "./components/features/Modal"
+import { Loading } from "./components/features/Loading"
+import { SaveBar } from "./components/features/SaveBar"
 import { Frame } from "./components/Frame"
 
 function App() {
   return (
     <Frame>
+      <Loading />
       <Modal />
+      <SaveBar />
 
       <EmbeddedApp />
     </Frame>

--- a/admin-frame/src/components/Frame.tsx
+++ b/admin-frame/src/components/Frame.tsx
@@ -1,8 +1,27 @@
+import { useNavMenuFeatureStore, type NavItem } from "../store/features/nav-menu";
+
 type Props = {
   children: React.ReactNode;
 }
 
+// Default Shopify admin navigation items
+const defaultNavItems: NavItem[] = [
+  { label: 'Home', href: '/', isHome: true },
+  { label: 'Orders', href: '/orders' },
+  { label: 'Products', href: '/products' },
+  { label: 'Customers', href: '/customers' },
+  { label: 'Content', href: '/content' },
+  { label: 'Analytics', href: '/analytics' },
+  { label: 'Marketing', href: '/marketing' },
+  { label: 'Discounts', href: '/discounts' },
+];
+
 export function Frame({ children }: Props) {
+  const appNavItems = useNavMenuFeatureStore(state => state.items);
+
+  // Use app nav items if provided, otherwise show default Shopify admin nav
+  const hasAppNav = appNavItems.length > 0;
+
   return (
     <div
       className="frame"
@@ -32,15 +51,46 @@ export function Frame({ children }: Props) {
           overflow: 'hidden',
         }}
       >
-        <div className="navigation" style={{ width: '240px', backgroundColor: 'rgb(235, 235, 235)' }}>
+        <div className="navigation" style={{ width: '240px', backgroundColor: 'rgb(235, 235, 235)', padding: '8px 0' }}>
+          {/* Default Shopify admin navigation */}
           <s-stack justifyContent="stretch">
-            <s-button variant="tertiary">Home</s-button>
-            <s-button variant="tertiary">Products</s-button>
-            <s-button variant="tertiary">Orders</s-button>
-            <s-button variant="tertiary">Customers</s-button>
-            <s-button variant="tertiary">Analytics</s-button>
-            <s-button variant="tertiary">Marketing</s-button>
+            {defaultNavItems.map((item, index) => (
+              <s-button
+                key={`default-${index}`}
+                variant="tertiary"
+              >
+                {item.label}
+              </s-button>
+            ))}
           </s-stack>
+
+          {/* App-specific navigation section */}
+          {hasAppNav && (
+            <>
+              <div style={{ borderTop: '1px solid #ccc', margin: '12px 8px' }} />
+              <div style={{ padding: '4px 12px', fontSize: '11px', color: '#666', fontWeight: 600, textTransform: 'uppercase' }}>
+                App
+              </div>
+              <s-stack justifyContent="stretch">
+                {appNavItems.map((item, index) => (
+                  <s-button
+                    key={`app-${index}`}
+                    variant="tertiary"
+                    onClick={() => {
+                      // Send navigation message to iframe
+                      const iframe = document.getElementById('app-iframe') as HTMLIFrameElement;
+                      iframe?.contentWindow?.postMessage({
+                        type: 'NAV_MENU_CLICK',
+                        href: item.href,
+                      }, '*');
+                    }}
+                  >
+                    {item.label}
+                  </s-button>
+                ))}
+              </s-stack>
+            </>
+          )}
         </div>
 
         <div

--- a/admin-frame/src/components/features/Loading.tsx
+++ b/admin-frame/src/components/features/Loading.tsx
@@ -1,0 +1,44 @@
+import { useLoadingFeatureStore } from "../../store/features/loading";
+
+export function Loading() {
+  const isLoading = useLoadingFeatureStore(state => state.isLoading);
+
+  if (!isLoading) return null;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        height: '3px',
+        backgroundColor: 'transparent',
+        zIndex: 9999,
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          width: '30%',
+          height: '100%',
+          backgroundColor: '#2c6ecb',
+          animation: 'loading-bar 1.5s ease-in-out infinite',
+        }}
+      />
+      <style>{`
+        @keyframes loading-bar {
+          0% {
+            transform: translateX(-100%);
+          }
+          50% {
+            transform: translateX(200%);
+          }
+          100% {
+            transform: translateX(400%);
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/admin-frame/src/components/features/SaveBar.tsx
+++ b/admin-frame/src/components/features/SaveBar.tsx
@@ -1,0 +1,91 @@
+import { useSaveBarFeatureStore } from "../../store/features/save-bar";
+
+export function SaveBar() {
+  const saveBars = useSaveBarFeatureStore(state => state.saveBars);
+  const hide = useSaveBarFeatureStore(state => state.hide);
+
+  // Get all visible save bars
+  const visibleSaveBars = Object.values(saveBars).filter(sb => sb.visible);
+
+  if (visibleSaveBars.length === 0) return null;
+
+  // Show the first visible save bar (typically there's only one at a time)
+  const activeSaveBar = visibleSaveBars[0];
+
+  const handleSave = () => {
+    // Send message to iframe to trigger save
+    const iframe = document.getElementById('app-iframe') as HTMLIFrameElement;
+    iframe?.contentWindow?.postMessage({
+      type: 'SAVE_BAR_SAVE',
+      id: activeSaveBar.id,
+    }, '*');
+  };
+
+  const handleDiscard = () => {
+    if (activeSaveBar.discardConfirmation) {
+      // Could show a confirmation dialog here
+      const confirmed = window.confirm('Discard all unsaved changes?');
+      if (!confirmed) return;
+    }
+
+    // Send message to iframe to trigger discard
+    const iframe = document.getElementById('app-iframe') as HTMLIFrameElement;
+    iframe?.contentWindow?.postMessage({
+      type: 'SAVE_BAR_DISCARD',
+      id: activeSaveBar.id,
+    }, '*');
+
+    hide({ id: activeSaveBar.id });
+  };
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        backgroundColor: '#1a1a1a',
+        padding: '12px 20px',
+        display: 'flex',
+        justifyContent: 'flex-end',
+        alignItems: 'center',
+        gap: '12px',
+        zIndex: 9998,
+        boxShadow: '0 -2px 10px rgba(0,0,0,0.2)',
+      }}
+    >
+      <span style={{ color: '#b5b5b5', marginRight: 'auto' }}>
+        Unsaved changes
+      </span>
+      <button
+        onClick={handleDiscard}
+        style={{
+          padding: '8px 16px',
+          backgroundColor: 'transparent',
+          color: '#fff',
+          border: '1px solid #5c5c5c',
+          borderRadius: '6px',
+          cursor: 'pointer',
+          fontSize: '14px',
+        }}
+      >
+        Discard
+      </button>
+      <button
+        onClick={handleSave}
+        style={{
+          padding: '8px 16px',
+          backgroundColor: '#2c6ecb',
+          color: '#fff',
+          border: 'none',
+          borderRadius: '6px',
+          cursor: 'pointer',
+          fontSize: '14px',
+        }}
+      >
+        Save
+      </button>
+    </div>
+  );
+}

--- a/admin-frame/src/hooks/useMockBridge.ts
+++ b/admin-frame/src/hooks/useMockBridge.ts
@@ -87,10 +87,11 @@ export function useMockBridge() {
           const { feature, action, payload } = event.data as FeatureActionRequest;
 
           const featureStore = getFeatureStore(feature);
-          const actionFn = featureStore.getState()[action];
+          const state = featureStore.getState() as Record<string, unknown>;
+          const actionFn = state[action as string];
 
-          if (actionFn) {
-            actionFn(payload);
+          if (typeof actionFn === 'function') {
+            (actionFn as (payload: unknown) => void)(payload);
           } else {
             console.warn('[MockAdmin] Unknown feature action:', action);
           }

--- a/admin-frame/src/store/features.ts
+++ b/admin-frame/src/store/features.ts
@@ -1,7 +1,13 @@
 import { useModalFeatureStore } from "./features/modal";
+import { useLoadingFeatureStore } from "./features/loading";
+import { useSaveBarFeatureStore } from "./features/save-bar";
+import { useNavMenuFeatureStore } from "./features/nav-menu";
 
 export const features = {
   modal: useModalFeatureStore,
+  loading: useLoadingFeatureStore,
+  saveBar: useSaveBarFeatureStore,
+  navMenu: useNavMenuFeatureStore,
 }
 
 export type FeatureName = keyof typeof features;

--- a/admin-frame/src/store/features/loading.ts
+++ b/admin-frame/src/store/features/loading.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+import { combine } from "zustand/middleware";
+
+type LoadingFeatureState = {
+  isLoading: boolean;
+}
+
+export const useLoadingFeatureStore = create(combine(
+  { isLoading: false } as LoadingFeatureState,
+  set => ({
+    setLoading: (payload: { isLoading: boolean }) => set({ isLoading: payload.isLoading }),
+  })
+));

--- a/admin-frame/src/store/features/nav-menu.ts
+++ b/admin-frame/src/store/features/nav-menu.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+import { combine } from "zustand/middleware";
+
+export type NavItem = {
+  label: string;
+  href: string;
+  isHome?: boolean;
+  active?: boolean;
+}
+
+type NavMenuFeatureState = {
+  items: NavItem[];
+}
+
+export const useNavMenuFeatureStore = create(combine(
+  { items: [] } as NavMenuFeatureState,
+  set => ({
+    setItems: (payload: { items: NavItem[] }) => set({ items: payload.items }),
+
+    addItem: (payload: NavItem) => set(state => ({
+      items: [...state.items, payload],
+    })),
+
+    clearItems: () => set({ items: [] }),
+  })
+));

--- a/admin-frame/src/store/features/save-bar.ts
+++ b/admin-frame/src/store/features/save-bar.ts
@@ -1,0 +1,66 @@
+import { create } from "zustand";
+import { combine } from "zustand/middleware";
+
+type SaveBarState = {
+  id: string;
+  visible: boolean;
+  discardConfirmation: boolean;
+}
+
+type SaveBarFeatureState = {
+  saveBars: Record<string, SaveBarState>;
+}
+
+const defaultSaveBarState: SaveBarState = {
+  id: '',
+  visible: false,
+  discardConfirmation: false,
+};
+
+export const useSaveBarFeatureStore = create(combine(
+  { saveBars: {} } as SaveBarFeatureState,
+  (set) => ({
+    show: (payload: { id: string }) => set(state => ({
+      saveBars: {
+        ...state.saveBars,
+        [payload.id]: {
+          ...(state.saveBars[payload.id] || { ...defaultSaveBarState, id: payload.id }),
+          visible: true,
+        },
+      },
+    })),
+
+    hide: (payload: { id: string }) => set(state => ({
+      saveBars: {
+        ...state.saveBars,
+        [payload.id]: {
+          ...(state.saveBars[payload.id] || { ...defaultSaveBarState, id: payload.id }),
+          visible: false,
+        },
+      },
+    })),
+
+    toggle: (payload: { id: string }) => set(state => {
+      const current = state.saveBars[payload.id];
+      return {
+        saveBars: {
+          ...state.saveBars,
+          [payload.id]: {
+            ...(current || { ...defaultSaveBarState, id: payload.id }),
+            visible: !current?.visible,
+          },
+        },
+      };
+    }),
+
+    update: (payload: { id: string; discardConfirmation?: boolean }) => set(state => ({
+      saveBars: {
+        ...state.saveBars,
+        [payload.id]: {
+          ...(state.saveBars[payload.id] || { ...defaultSaveBarState, id: payload.id }),
+          discardConfirmation: payload.discardConfirmation ?? false,
+        },
+      },
+    })),
+  })
+));

--- a/app-bridge/src/features/loading.ts
+++ b/app-bridge/src/features/loading.ts
@@ -1,0 +1,8 @@
+import { invokeFeature } from "../invokeFeature";
+
+export function loading(): (isLoading: boolean) => void {
+  return (isLoading: boolean) => {
+    console.log('[MockAppBridge] Loading:', isLoading);
+    invokeFeature('loading', 'setLoading', { isLoading });
+  };
+}

--- a/app-bridge/src/features/nav-menu.ts
+++ b/app-bridge/src/features/nav-menu.ts
@@ -1,0 +1,109 @@
+import { invokeFeature } from "../invokeFeature";
+
+type NavItem = {
+  label: string;
+  href: string;
+  isHome?: boolean;
+}
+
+/**
+ * Observe ui-nav-menu elements and extract navigation items
+ */
+function observeNavMenuElements() {
+  function extractNavItems(navMenu: HTMLElement): NavItem[] {
+    const items: NavItem[] = [];
+
+    // Look for a elements or ui-link/s-link elements
+    const links = navMenu.querySelectorAll('a, ui-link, s-link');
+
+    links.forEach((link) => {
+      const href = link.getAttribute('href') || '/';
+      const label = link.textContent?.trim() || '';
+      const isHome = link.getAttribute('rel') === 'home';
+
+      if (label) {
+        items.push({ label, href, isHome });
+      }
+    });
+
+    return items;
+  }
+
+  function setupNavMenu(navMenu: HTMLElement) {
+    // Hide the native element
+    navMenu.style.display = 'none';
+
+    // Extract and send nav items to parent
+    const items = extractNavItems(navMenu);
+    if (items.length > 0) {
+      invokeFeature('navMenu', 'setItems', { items });
+    }
+
+    // Watch for changes to the nav menu
+    const observer = new MutationObserver(() => {
+      const updatedItems = extractNavItems(navMenu);
+      invokeFeature('navMenu', 'setItems', { items: updatedItems });
+    });
+
+    observer.observe(navMenu, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+  }
+
+  // Initial scan for nav menu elements
+  function observeElements() {
+    // Support multiple nav menu element names
+    const selectors = ['ui-nav-menu', 'nav-menu', 's-app-nav'];
+    selectors.forEach(selector => {
+      document.querySelectorAll(selector).forEach(el => setupNavMenu(el as HTMLElement));
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', observeElements);
+  } else {
+    observeElements();
+  }
+
+  // Watch for new nav menu elements
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach(mutation => {
+      mutation.addedNodes.forEach(node => {
+        if (node instanceof HTMLElement) {
+          const tagName = node.tagName.toLowerCase();
+          if (['ui-nav-menu', 'nav-menu', 's-app-nav'].includes(tagName)) {
+            setupNavMenu(node);
+          }
+        }
+      });
+    });
+  });
+
+  observer.observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+  });
+
+  // Listen for nav click events from parent
+  window.addEventListener('message', (event) => {
+    if (event.data?.type === 'NAV_MENU_CLICK') {
+      // Navigate within the app
+      const href = event.data.href;
+      if (href) {
+        window.location.href = href;
+      }
+    }
+  });
+}
+
+export function navMenu() {
+  // Start observing nav menu elements when the API is initialized
+  if (typeof document !== 'undefined') {
+    observeNavMenuElements();
+  }
+
+  // The navMenu doesn't have a direct API - it works through the ui-nav-menu element
+  return {};
+}

--- a/app-bridge/src/features/save-bar.ts
+++ b/app-bridge/src/features/save-bar.ts
@@ -1,8 +1,139 @@
+import { invokeFeature } from "../invokeFeature";
+
+/**
+ * Observe ui-save-bar elements and forms with data-save-bar attribute
+ */
+function observeSaveBarElements() {
+  // Observe ui-save-bar elements
+  function setupSaveBar(element: HTMLElement) {
+    const id = element.getAttribute('id');
+    if (!id) return;
+
+    // Hide the native element
+    element.style.display = 'none';
+
+    // Check for discard confirmation
+    const discardConfirmation = element.hasAttribute('data-discard-confirmation');
+
+    // Register with parent
+    invokeFeature('saveBar', 'update', { id, discardConfirmation });
+
+    // Override show/hide methods
+    (element as any).show = () => {
+      invokeFeature('saveBar', 'show', { id });
+    };
+
+    (element as any).hide = () => {
+      invokeFeature('saveBar', 'hide', { id });
+    };
+  }
+
+  // Observe forms with data-save-bar attribute
+  function setupFormSaveBar(form: HTMLFormElement) {
+    const id = `form-save-bar-${Date.now()}`;
+    const discardConfirmation = form.hasAttribute('data-discard-confirmation');
+
+    // Track form changes
+    let isDirty = false;
+    const originalValues = new Map<string, string>();
+
+    // Store original values
+    const inputs = form.querySelectorAll('input, textarea, select');
+    inputs.forEach((input: Element) => {
+      const el = input as HTMLInputElement;
+      originalValues.set(el.name || el.id, el.value);
+    });
+
+    // Listen for changes
+    form.addEventListener('input', () => {
+      let hasChanges = false;
+      inputs.forEach((input: Element) => {
+        const el = input as HTMLInputElement;
+        const key = el.name || el.id;
+        if (originalValues.get(key) !== el.value) {
+          hasChanges = true;
+        }
+      });
+
+      if (hasChanges && !isDirty) {
+        isDirty = true;
+        invokeFeature('saveBar', 'show', { id });
+      } else if (!hasChanges && isDirty) {
+        isDirty = false;
+        invokeFeature('saveBar', 'hide', { id });
+      }
+    });
+
+    // Listen for save bar events from parent
+    window.addEventListener('message', (event) => {
+      if (event.data?.type === 'SAVE_BAR_SAVE' && event.data.id === id) {
+        form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+        isDirty = false;
+        invokeFeature('saveBar', 'hide', { id });
+      }
+      if (event.data?.type === 'SAVE_BAR_DISCARD' && event.data.id === id) {
+        form.reset();
+        isDirty = false;
+      }
+    });
+
+    // Register with parent
+    invokeFeature('saveBar', 'update', { id, discardConfirmation });
+  }
+
+  // Initial scan
+  function observeElements() {
+    document.querySelectorAll('ui-save-bar').forEach(el => setupSaveBar(el as HTMLElement));
+    document.querySelectorAll('form[data-save-bar]').forEach(el => setupFormSaveBar(el as HTMLFormElement));
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', observeElements);
+  } else {
+    observeElements();
+  }
+
+  // Watch for new elements
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach(mutation => {
+      mutation.addedNodes.forEach(node => {
+        if (node instanceof HTMLElement) {
+          if (node.tagName.toLowerCase() === 'ui-save-bar') {
+            setupSaveBar(node);
+          }
+          if (node.tagName === 'FORM' && node.hasAttribute('data-save-bar')) {
+            setupFormSaveBar(node as HTMLFormElement);
+          }
+        }
+      });
+    });
+  });
+
+  observer.observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+  });
+}
+
 export function saveBar(): NonNullable<typeof window.shopify>['saveBar'] {
+  // Start observing save bar elements when the API is initialized
+  if (typeof document !== 'undefined') {
+    observeSaveBarElements();
+  }
+
   return {
-    leaveConfirmation: async () => {},
-    toggle: async () => {},
-    hide: async () => {},
-    show: async () => {},
+    show: async (id: string) => {
+      await invokeFeature('saveBar', 'show', { id });
+    },
+    hide: async (id: string) => {
+      await invokeFeature('saveBar', 'hide', { id });
+    },
+    toggle: async (id: string) => {
+      await invokeFeature('saveBar', 'toggle', { id });
+    },
+    leaveConfirmation: async () => {
+      // This is called before navigation to check if there are unsaved changes
+      // For mock purposes, we just resolve
+    },
   };
 }

--- a/app-bridge/src/index.ts
+++ b/app-bridge/src/index.ts
@@ -19,6 +19,8 @@ import { support } from "./features/support";
 import { reviews } from "./features/reviews";
 import { picker } from "./features/picker";
 import { app } from "./features/app";
+import { loading } from "./features/loading";
+import { navMenu } from "./features/nav-menu";
 
 (function (window) {
   'use strict';
@@ -359,7 +361,7 @@ import { app } from "./features/app";
 
     // Lifecycle methods
     ready: Promise.resolve(),
-    loading: () => void 0,
+    loading: loading(),
 
     // Origin should be empty string for mock
     origin: '',
@@ -403,6 +405,9 @@ import { app } from "./features/app";
       platform: platform,
     };
   }
+
+  // Initialize nav menu observer
+  navMenu();
 
   console.log('[MockAppBridge] Client library loaded');
 

--- a/test-app/src/main.ts
+++ b/test-app/src/main.ts
@@ -11,6 +11,12 @@ declare global {
       toast: {
         show(message: string, options?: { duration?: number }): Promise<void>;
       };
+      saveBar: {
+        show(id: string): Promise<void>;
+        hide(id: string): Promise<void>;
+        toggle(id: string): Promise<void>;
+      };
+      loading(isLoading: boolean): void;
       idToken(): Promise<string>;
     };
   }
@@ -60,10 +66,33 @@ async function init() {
     <h1>Mock Bridge Test App</h1>
     <div id="status">Initializing...</div>
     <hr>
+
     <h2>Test Actions</h2>
-    <button id="show-modal">Show Modal</button>
-    <button id="show-toast">Show Toast</button>
-    <button id="get-token">Get Session Token</button>
+    <div class="button-group">
+      <button id="show-modal">Show Modal</button>
+      <button id="show-toast">Show Toast</button>
+      <button id="get-token">Get Session Token</button>
+    </div>
+
+    <h3>Loading API</h3>
+    <div class="button-group">
+      <button id="start-loading">Start Loading</button>
+      <button id="stop-loading">Stop Loading</button>
+    </div>
+
+    <h3>Save Bar API</h3>
+    <div class="button-group">
+      <button id="show-savebar">Show Save Bar</button>
+      <button id="hide-savebar">Hide Save Bar</button>
+    </div>
+
+    <h3>Form with Auto Save Bar</h3>
+    <form id="test-form" data-save-bar data-discard-confirmation>
+      <label>
+        Name: <input type="text" name="name" value="Original Value" />
+      </label>
+    </form>
+
     <hr>
     <h2>Results</h2>
     <pre id="results"></pre>
@@ -80,6 +109,17 @@ async function init() {
         <button id="modal-cancel-btn">Cancel</button>
       </ui-title-bar>
     </ui-modal>
+
+    <!-- Save Bar definition -->
+    <ui-save-bar id="my-save-bar"></ui-save-bar>
+
+    <!-- Navigation Menu definition (will appear in sidebar) -->
+    <ui-nav-menu>
+      <a href="/" rel="home">Home</a>
+      <a href="/settings">Settings</a>
+      <a href="/products">Products</a>
+      <a href="/orders">Orders</a>
+    </ui-nav-menu>
   `;
 
   const status = document.getElementById('status')!;
@@ -121,10 +161,8 @@ async function init() {
   }
 
   // Modal test - using the Shopify App Bridge pattern
-  // The modal content is defined in <ui-modal id="my-modal"> element above
   document.getElementById('show-modal')?.addEventListener('click', async () => {
     try {
-      // Can use either shopify.modal.show() or element.show()
       await window.shopify.modal.show('my-modal');
       results.textContent = 'Modal shown successfully';
     } catch (e) {
@@ -161,6 +199,42 @@ async function init() {
     } catch (e) {
       results.textContent = `Token error: ${e}`;
     }
+  });
+
+  // Loading API tests
+  document.getElementById('start-loading')?.addEventListener('click', () => {
+    window.shopify.loading(true);
+    results.textContent = 'Loading started - check the top of the page for the loading bar';
+  });
+
+  document.getElementById('stop-loading')?.addEventListener('click', () => {
+    window.shopify.loading(false);
+    results.textContent = 'Loading stopped';
+  });
+
+  // Save Bar API tests
+  document.getElementById('show-savebar')?.addEventListener('click', async () => {
+    try {
+      await window.shopify.saveBar.show('my-save-bar');
+      results.textContent = 'Save bar shown - check the bottom of the page';
+    } catch (e) {
+      results.textContent = `Save bar error: ${e}`;
+    }
+  });
+
+  document.getElementById('hide-savebar')?.addEventListener('click', async () => {
+    try {
+      await window.shopify.saveBar.hide('my-save-bar');
+      results.textContent = 'Save bar hidden';
+    } catch (e) {
+      results.textContent = `Save bar error: ${e}`;
+    }
+  });
+
+  // Form submission handler
+  document.getElementById('test-form')?.addEventListener('submit', (e) => {
+    e.preventDefault();
+    results.textContent = 'Form submitted! Save bar should hide automatically.';
   });
 }
 

--- a/test-app/src/style.css
+++ b/test-app/src/style.css
@@ -5,13 +5,45 @@ body {
   margin: 0 auto;
 }
 button {
-  padding: 10px 20px;
-  margin: 5px;
+  padding: 8px 16px;
+  margin: 4px;
   cursor: pointer;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #fff;
+}
+button:hover {
+  background: #f0f0f0;
 }
 pre {
   background: #f5f5f5;
   padding: 15px;
   border-radius: 4px;
   overflow-x: auto;
+  min-height: 40px;
+}
+.button-group {
+  margin: 10px 0;
+}
+h3 {
+  margin-top: 20px;
+  margin-bottom: 8px;
+  font-size: 14px;
+  color: #666;
+}
+form {
+  margin: 10px 0;
+  padding: 15px;
+  background: #f9f9f9;
+  border-radius: 4px;
+}
+label {
+  display: block;
+  margin-bottom: 8px;
+}
+input {
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  margin-left: 8px;
 }


### PR DESCRIPTION
## Summary
- **Loading API** (#5): `shopify.loading(boolean)` shows animated bar at top of page
- **Save Bar API** (#6): `shopify.saveBar.show/hide/toggle` with Discard/Save buttons at bottom
- **NavMenu** (#1): Observes `<ui-nav-menu>` elements and displays app navigation in sidebar

## Implementation Details

### Loading Feature
- Zustand store at `admin-frame/src/store/features/loading.ts`
- Animated Loading component shows blue bar at top when active
- API: `shopify.loading(true/false)`

### Save Bar Feature  
- Zustand store managing multiple save bars by ID
- SaveBar component with "Unsaved changes", Discard, and Save buttons
- Supports `data-save-bar` and `data-discard-confirmation` form attributes
- Sends SAVE_BAR_SAVE/SAVE_BAR_DISCARD postMessage events to iframe

### NavMenu Feature
- Observes `<ui-nav-menu>` elements in embedded app
- Extracts navigation items and syncs to admin frame
- Displays under "APP" section in sidebar

## Test Plan
- [x] Loading bar appears when `shopify.loading(true)` is called
- [x] Save bar appears with correct buttons when shown
- [x] NavMenu items appear in sidebar under APP section
- [x] Modal still works correctly
- [x] All features verified with Playwright browser testing

## Screenshots
Screenshots available in repo: features-test.png, savebar-feature.png, loading-feature.png, modal-feature.png

🤖 Generated with [Claude Code](https://claude.com/claude-code)