### PR TITLE
Fix prepare script peer dep conflict in admin-frame

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start": "node dist/server/index.js",
     "watch": "tsc --watch",
     "clean": "rm -rf dist",
-    "prepare": "cd admin-frame && npm install && cd ../app-bridge && npm install && cd .. && npm run build"
+    "prepare": "cd admin-frame && npm install --legacy-peer-deps && cd ../app-bridge && npm install && cd .. && npm run build"
   },
   "keywords": [
     "shopify",


### PR DESCRIPTION
## Summary
- Adds `--legacy-peer-deps` to the admin-frame `npm install` in the `prepare` script
- Fixes `@shopify/polaris` requiring `react ^18` while admin-frame uses `react 19`
- Without this, `npm install` and `npm publish` fail when the `prepare` script runs

## Context
Reported by a user testing the `http-proxy-middleware` branch — `npm install` fails out of the box due to this peer dep conflict.

## Test plan
- [ ] `npm install` succeeds without manual intervention
- [ ] `npm publish` completes successfully
- [ ] `npx github:ctrlaltdylan/mock-bridge#main` works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)